### PR TITLE
Adding Error Handling Messages for double Stop/Go

### DIFF
--- a/view/src/application/ErrorHandling.java
+++ b/view/src/application/ErrorHandling.java
@@ -1,1 +1,30 @@
+package application;
 
+public class ErrorHandling extends Thread{
+	public ErrorHandling() {
+	}
+	
+	public static String fraeskopfRunning() {
+		//TODO: Rephrase following
+		return "Der Fraeskopf wurde versucht anzuschalten, obwohl er bereits läuft.";
+	}
+	
+	public static String fraeskopfStopped() {
+		//TODO: Rephrase following
+		return "Der Fraeskopf wurde versucht auszuschalten, obwohl er nicht lief.";
+	}
+	
+	public static String spindelStopped() {
+		//TODO: Rephrase following
+		return "Die Spindel wurde versucht auszuschalten, obwohl sie nicht lief.";
+	}
+	
+	public static String spindelRunning() {
+		//TODO: Rephrase following
+		return "Die Spindel wurde versucht anzuschalten, obwohl sie läuft.";
+	}
+	
+	public void run() {
+		
+	}
+}

--- a/view/src/application/Fraeskopf.java
+++ b/view/src/application/Fraeskopf.java
@@ -49,7 +49,7 @@ public class Fraeskopf extends Thread
 			fraesenStatus = true;
 		}
 		else {
-			//TODO: Fehlermeldung, wenn Fraese bereits angeschaltet
+			ErrorHandling.fraeskopfRunning();
 		}
 	}
 	
@@ -58,7 +58,7 @@ public class Fraeskopf extends Thread
 			fraesenStatus = false;
 		}
 		else {
-			//TODO: Fehlermeldung, wenn Fraese gar nicht an war
+			ErrorHandling.fraeskopfStopped();
 		}
 	}
 	

--- a/view/src/application/Main.java
+++ b/view/src/application/Main.java
@@ -21,6 +21,7 @@ public class Main extends Application {
 	
 public static Fraeskopf fraeskopf = new Fraeskopf();
 public static Kuehlmittel kuehlmittel = new Kuehlmittel();
+public static ErrorHandling errorHandling = new ErrorHandling();
 	
 	@Override
 	public void start(Stage primaryStage) {

--- a/view/src/application/Spindel.java
+++ b/view/src/application/Spindel.java
@@ -12,7 +12,7 @@ public class Spindel extends Thread{
 			spindelStatus = false;
 		}
 		else {
-			//TODO: Fehlermeldung, dass Spindel nicht laeuft
+			ErrorHandling.spindelStopped();
 		}
 	}
 	
@@ -21,7 +21,7 @@ public class Spindel extends Thread{
 			spindelStatus = true;
 		}
 		else {
-			//TODO: Fehlermeldung, dass Spindel laeuft 
+			ErrorHandling.spindelRunning();
 		}
 	}
 	


### PR DESCRIPTION
Error Handling Messages for when Spindel/Fraeskopf are already running/stopped and are attempted to be stopped/run again